### PR TITLE
README.md: add Arch AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ bugs and snakes, and count the directories in your $HOME after you use
 
 ### Install
 
+#### Arch Linux
+
+```
+yay hxd
+```
+
 #### Requirements
 
 - A POSIX system. (Windows is not supported at present.)


### PR DESCRIPTION
Arch Linux can easily install hxd via Arch AUR. This pull request adds this to the README.