### PR TITLE
better AL install

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,11 @@ codepoint:
 
 #### Arch Linux
 
+[huxdemp](https://aur.archlinux.org/packages/huxdemp) (release, bin), [huxdemp-git](https://aur.archlinux.org/packages/huxdemp-git) (src, git)
+
 ```
-yay huxd
+yay huxdemp
+yay huxdemp-git
 ```
 
 #### Gentoo


### PR DESCRIPTION
- `huxd` AUR package has been renamed `huxdemp`
- add huxdemp-git too